### PR TITLE
Fixed Door Sensor Operation

### DIFF
--- a/config/All Configuration Parameters.js
+++ b/config/All Configuration Parameters.js
@@ -138,11 +138,7 @@
 	"unlockValue": 0,
 	
 	"doorSensorRef":0,
-	"openValue": 255,
-	"closedValue": 0,
-	"openingValue": 254,
-	"closingValue": 252,
-	"stoppedValue": 253	
+	"doorSensorClosedValues":[0]
 },
 
 {

--- a/index.js
+++ b/index.js
@@ -172,7 +172,9 @@ HomeSeerPlatform.prototype =
 							
 						} catch(err) 
 							{
-							globals.log(red(`${err} resulting in problem creating new HomeSeerAccessory. This may be the result of specifying an incorrect HomeSeer reference number in your config.json file. You specified reference ${cyan(currentAccessory.ref)}, Check all reference numbers and be sure HomeSeer is running. Continuing to add other accessories.`))
+							globals.log(red(`${err} resulting in problem creating new HomeSeerAccessory. This may be the result of specifying an incorrect HomeSeer reference number in your config.json file. You specified reference ${cyan(currentAccessory.ref)}, Check all reference numbers and be sure HomeSeer is running. Stopping homebridge.`))
+							
+							throw err;
 							
 						}			
 

--- a/lib/HomeKitDeviceSetup.js
+++ b/lib/HomeKitDeviceSetup.js
@@ -966,45 +966,22 @@ exports.setupServices = function (that, services)
 				lockMgmtService.getCharacteristic(Characteristic.Version).updateValue("1.0");
 				lockMgmtService.addCharacteristic(Characteristic.CurrentDoorState).updateValue(1);
 				
+			var currentDoorState = lockMgmtService.getCharacteristic(Characteristic.CurrentDoorState);
+				
 			//This is for a simple door open/closed sensor. Though supported by lockManagement, it seems to do nothing!
 			if(that.config.doorSensorRef)
 			{
 					if( that.config.doorSensorClosedValues === undefined) {that.config.doorSensorClosedValues = [0]};
 				
-					lockMgmtService.getCharacteristic(Characteristic.CurrentDoorState)
-					.updateUsingHSReference(that.config.doorSensorRef)
-					.setConfigValues(that.config)
-					.on('HSvalueChanged', (newHSValue, homekitObject) => { 
-						
-						globals.log(yellow(`You have a Door Sensor Reference# ${cyan(that.config.doorSensorRef)} specified for a Lock having a reference ${cyan(that.config.ref)}. Specifying a Door Sensor Reference currently does nothing.`));
-						
-	 
-							if (homekitObject.config.doorSensorClosedValues.includes(newHSValue))
-									{ homekitObject.updateValue(1); }
+					currentDoorState
+						.updateUsingHSReference(that.config.doorSensorRef)
+						.setConfigValues(that.config)
+						.on('HSvalueChanged', (newHSValue, homekitObject) => 
+						{ 
+							if (currentDoorState.config.doorSensorClosedValues.includes(newHSValue))
+									{ currentDoorState.updateValue(1); }
 								else
-									{ 	homekitObject.updateValue(0); }		
-
-							switch( homekitObject.value)
-							{
-								case 0:
-								{
-								globals.log(yellow(`Door Sensor Reference# ${cyan(that.config.doorSensorRef)} indicates the Lock having a reference ${cyan(that.config.ref)} is Open. Door Sensor Reference currently does nothing else.`));
-								break;
-
-								}
-								case 1:
-								{
-								globals.log(yellow(`Door Sensor Reference# ${cyan(that.config.doorSensorRef)} indicates the Lock having a reference ${cyan(that.config.ref)} is Closed. Door Sensor Reference currently does nothing else.`));
-								break;
-								}
-								default:
-								{
-								globals.log(yellow(`Door Sensor Reference# ${cyan(that.config.doorSensorRef)} indicates the Lock having a reference ${cyan(that.config.ref)} is Neither fully opened or closed. Door Sensor Reference currently does nothing else.`));
-								break;
-								}
-							}
-							
-						
+									{ 	currentDoorState.updateValue(0); }		
 						});		
 			}
 
@@ -1145,8 +1122,38 @@ exports.setupServices = function (that, services)
 				.on('set', function(value, callback, context)
 							{
 
-								(value) ? HomeSeerData.sendDataValue(that.config.ref , this.config.lockValue) : HomeSeerData.sendDataValue(that.config.ref, this.config.unlockValue)
+								switch (value)
+								{	
+									case 0: // unlock the door
+										{
+											HomeSeerData.sendDataValue(that.config.ref, this.config.unlockValue);
+											break
+										}								
+									case 1: // lock the door
+										{
+											if(currentDoorState.value === 0)
+											{
+												globals.log(yellow(`Warning - The Door with HomeSeer Reference ${lockService.config.ref} is open and you're attempting to extend the lock cylinder. To prevent damage to door frame, this command will be ignored!`));
+												
+												setTimeout(function() // Wait a few seconds then restore the lock to an unlocked state
+													{
+															lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(0);
+															lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(0)
+													}, 3000)
+											}
+											else
+											{
+												HomeSeerData.sendDataValue(that.config.ref , this.config.lockValue);
+											}
+											break;
+										}
+									default:
+										{
+											globals.log(red(`Error - incorrect value for a Lock Target State.`));
 
+										}
+
+								}
 								callback(null);
 							} );
 		

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-homeseer4",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "HomeSeer 3 and HomeSeer 4 Plugin for homebridge. This updates and replaces homebridge-homeseer-plugin-2018. See: https://github.com/jvmahon/homebridge-homeseer4",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
The code now recognizes a door sensor and if the door is open, it prevents locking the door.

After implementing this, I realized it would be better to handle the interaction between a door sensor and the door lock directly within HomeSeer as that would give better control. For example, by setting an event where, each time the door lock is switched from unlocked to locked, you could check the sensor and see if the door should be locked. That would allow you to catch both HomeSeer as well as iOS locking errors.

But I have the code working, so I might as well leave it in now.