### PR TITLE
Hotfix: Fix for Fetch-related Timing Error

### DIFF
--- a/lib/HomeSeerSystemObject.js
+++ b/lib/HomeSeerSystemObject.js
@@ -466,32 +466,43 @@ class HomeSeerSystem
 		// console.log(yellow("*Debug* - categories URL: " + this.network.categoriesURL.href ));
 		
 		var that = this;
-		// var getStatusInfo 	= await promiseHTTP({ uri:statusURL.href, json:true, strictSSL:false})
-		// var getControlInfo 	= await promiseHTTP({ uri:controlURL.href, json:true, strictSSL:false})
-		
-		var getStatusInfo = 	await fetch(statusURL).then ( response => response.json() );
-		var getControlInfo = 	await fetch(controlURL).then ( response => response.json() );
 
+		// wait for both fetches to finish before resolving the Promise
+		await Promise.all([fetch(statusURL), fetch(controlURL)])
+		.then(function (responses) {
+			// Get a JSON object from each of the responses
+			return Promise.all(
+			responses.map(function (response) {
+				return response.json();
+			})
+			);
+		})
+		.then(function (data) {
+			let getStatusInfo = data[0];
+			let getControlInfo = data[1];
 
-		
-		for(var currentDevice of getStatusInfo.Devices)
-		{
-			if (that.HomeSeerDevices[currentDevice.ref] === undefined) that.HomeSeerDevices[currentDevice.ref] =  {status: undefined};
-			
+			for (var currentDevice of getStatusInfo.Devices) {
+			if (that.HomeSeerDevices[currentDevice.ref] === undefined)
+				that.HomeSeerDevices[currentDevice.ref] = { status: undefined };
 			that.HomeSeerDevices[currentDevice.ref].status = currentDevice;
-		}
-	
+			}
 
-		for(var currentDevice of getControlInfo.Devices)
-		{
-			if (that.HomeSeerDevices[currentDevice.ref] === undefined) that.HomeSeerDevices[currentDevice.ref] =  {ControlPairs: undefined};
-			
-			that.HomeSeerDevices[currentDevice.ref].ControlPairs = currentDevice.ControlPairs;
-		}
+			for (var currentDevice of getControlInfo.Devices) {
+			if (that.HomeSeerDevices[currentDevice.ref] === undefined)
+				that.HomeSeerDevices[currentDevice.ref] = {
+				ControlPairs: undefined,
+				};
+			that.HomeSeerDevices[currentDevice.ref].ControlPairs =
+				currentDevice.ControlPairs;
+			}
 
-		// console.log(red("*Debug* - Done Initializing the HomeSeer System. Item count is: " + that.HomeSeerDevices.length ));; 
-		that.initialized = true;
-		return Promise.resolve(true);;
+			// console.log(red("*Debug* - Done Initializing the HomeSeer System. Item count is: " + that.HomeSeerDevices.length ));;
+			that.initialized = true;
+			return Promise.resolve(true);
+		})
+		.catch(function (error) {
+			console.log(error);
+		});
 	}	
 }
 


### PR DESCRIPTION
Fixes #116 via a similar-ish approach mentioned by @jvmahon [here](https://github.com/jvmahon/Homebridge-HomeSeer4/issues/116#issuecomment-706695046). Basically just waits for both fetch requests fo finish before resolving the Promise.

Tested locally on HS4 so this should hopefully do the trick... 🤞 

Side note: I'd strongly recommend running these couple of files through Prettier to keep the formatting consistent. Makes quick PR's like this so much easier to get in and not trip over spaces vs tabs etc.