### PR TITLE
Implement while loop for initial fetches

### DIFF
--- a/lib/HomeSeerSystemObject.js
+++ b/lib/HomeSeerSystemObject.js
@@ -468,12 +468,21 @@ class HomeSeerSystem
 		var that = this;
 		// var getStatusInfo 	= await promiseHTTP({ uri:statusURL.href, json:true, strictSSL:false})
 		// var getControlInfo 	= await promiseHTTP({ uri:controlURL.href, json:true, strictSSL:false})
-		
-		var getStatusInfo = 	await fetch(statusURL).then ( response => response.json() );
-		var getControlInfo = 	await fetch(controlURL).then ( response => response.json() );
 
+		var getStatusInfo;
+		var getControlInfo;
+		var flag = false;
+		while (!flag) {
+			try {
+				getStatusInfo = await fetch(statusURL).then(response => response.json());
+				getControlInfo = await fetch(controlURL).then(response => response.json());
+  				flag = true;
+  			} catch (err) {
+				console.log("Failed to fetch HomeSeer device and control data, retrying in 5 seconds...");
+				await new Promise(resolve => setTimeout(resolve, 5000));
+			}
+		}
 
-		
 		for(var currentDevice of getStatusInfo.Devices)
 		{
 			if (that.HomeSeerDevices[currentDevice.ref] === undefined) that.HomeSeerDevices[currentDevice.ref] =  {status: undefined};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "homebridge-homeseer-plugin"
   ],
   "repository": "github:jvmahon/homebridge-homeseer4",
-  
   "bugs": {
     "url": "https://github.com/jvmahon/homebridge-homeseer4/issues"
   },
@@ -21,10 +20,10 @@
     "homebridge": ">=1.0.0"
   },
   "dependencies": {
-    "node-fetch" : ">=2.6.0",
+    "node-fetch": ">=2.6.0",
     "chalk": ">=4.0.0",
     "update-notifier": ">=4.1.0",
-    "url":">=0.11.0",
-    "queue":">=6.0.1"
+    "url": ">=0.11.0",
+    "queue": ">=6.0.1"
   }
 }


### PR DESCRIPTION
Simple while loop prevents the initialization from continuing unless both fetches (status and control) return successfully. This blocks the startup of Homebridge until HomeSeer is started, ensuring that HomeSeer devices will be set up in Homebridge.

Related issues/PRs: #120. #116.

Tested with HS4:
- Start Homebridge without HomeSeer started.
- Homebridge indicates an error that it cannot fetch data from HomeSeer.
- Start HomeSeer.
- Homebridge connects and completes startup.