### PR TITLE
Update DeviceDefaults.js

### DIFF
--- a/lib/DeviceDefaults.js
+++ b/lib/DeviceDefaults.js
@@ -197,7 +197,7 @@ var typeProperties =
 			"name":null,
 			"ref": 0,
 			"uuid_base": 0,
-			"offValues":[0, 254], 	// Values reported from HomeSeer when alert is 'off' / nothing triggered!
+			"offValues":[0, 23, 254], 	// Values reported from HomeSeer when alert is 'off' / nothing triggered!
 			"batteryRef": 0,
 			"batteryThreshold": 25,
 			"tamperRef":0,


### PR DESCRIPTION
Add "23" to off value for contact sensors. A lot of Z-Wave contact sensors use 22 for open, and 23 for closed. This change would allow those contact sensors to be setup under the simple config file format, vs having to do a complex config file format for them.