### PR TITLE
Change service fanv2 to fan for iOS 16

### DIFF
--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -112,7 +112,7 @@ exports.setupLightsFansPlugs = function (newDevice, services) {
 					}
 					break;
 				case "MultilevelFan":
-					var thisService = new Service.Fanv2();
+					var thisService = new Service.Fan();
 					var onControl	= thisService.getCharacteristic(Characteristic.Active)
 					var multilevelControl = thisService.addCharacteristic(new Characteristic.RotationSpeed())
 					break;


### PR DESCRIPTION
Changing the service from fanv2 to fan allows iOS 16 users to change their fan icons in the Home App.