### PR TITLE
Change service fanv2 to fan (Binary Fan

### DIFF
--- a/lib/Setup LightsFansPlugs.js
+++ b/lib/Setup LightsFansPlugs.js
@@ -38,7 +38,7 @@ exports.setupLightsFansPlugs = function (newDevice, services) {
 					var onControl	= thisService.getCharacteristic(Characteristic.On);
 					break;
 				case "binaryfan":
-					var thisService = new Service.Fanv2()
+					var thisService = new Service.Fan()
 					var onControl	= thisService.getCharacteristic(Characteristic.Active);
 					break;
 				default:


### PR DESCRIPTION
Changing the service from fanv2 to fan allows users to change their fan icons in the Home App. Pull request already put through for multi-level fans, this pull request is for binary fans. Tested and working on iOS 15 and 16.