### PR TITLE
Update config.schema.json

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -365,7 +365,7 @@
 				"type": "number"
 			},
 	        "valueTxt": {
-				"type": "text"
+				"type": "string"
 			}
 		}
 	},


### PR DESCRIPTION
Realized that setting the uuid_base under advanced setup had no effect to the config file. Changed type from "text" to "string", tested, and works as expected. Could also be an integer, but string allows "Ref1099.1" naming scheme as shown under the wiki "Show the same device in multiple rooms".