### PR TITLE
Virtual garage door "simple" config

### DIFF
--- a/lib/Setup LocksDoorsWindows.js
+++ b/lib/Setup LocksDoorsWindows.js
@@ -52,6 +52,13 @@ exports.setupLocksDoorsWindows = function (newDevice, services) {
 			currentDoorState.setConfigValues(newDevice.config);
 
 				switch (newDevice.config.interface_name) {
+					case ("Unknown"):
+						newDevice.config.openValue		=	255 // Open
+						newDevice.config.closedValue	=	0 	// Closed
+						newDevice.config.openingValue	=	254 // Opening
+						newDevice.config.closingValue	=	252 // Closing
+						newDevice.config.stoppedValue	=	253 // Stopped
+						break;
 					case ("Z-Wave"):
 						newDevice.config.openValue		=	255 // Open
 						newDevice.config.closedValue	=	0 	// Closed
@@ -120,6 +127,25 @@ exports.setupLocksDoorsWindows = function (newDevice, services) {
 						}
 					});
 
+if (newDevice.config.interface_name === "Unknown") {
+globals.log("Garage Door interface is " + newDevice.config.interface_name + ", using openingValue and closingValue to control door.")
+			targetDoorState
+				.on('set', (value, callback) =>{
+						switch(value){
+							case 0:  // Command to HomeSeer to Open Door
+									HomeSeerData.sendDataValue(newDevice.config.ref, targetDoorState.config.openingValue); 
+									break;
+							case 1:  // Command to HomeSeer to Close Door
+									HomeSeerData.sendDataValue(newDevice.config.ref, targetDoorState.config.closingValue); 
+									break; 
+						}
+						callback(null);
+					} );	
+					
+}
+
+if (newDevice.config.interface_name != "Unknown") {
+globals.log("Garage Door interface is " + newDevice.config.interface_name + ", using openValue and closedValue to control door.")
 			targetDoorState
 				.on('set', (value, callback) =>{
 						switch(value){
@@ -131,7 +157,10 @@ exports.setupLocksDoorsWindows = function (newDevice, services) {
 									break; 
 						}
 						callback(null);
-					} );					
+					} );	
+					
+}
+			
 
 			if(newDevice.config.obstructionRef){
 			thisService.getCharacteristic(Characteristic.ObstructionDetected)


### PR DESCRIPTION
This allows you to use a mimo-lite relay to control your garage door and use the simple config. If Homebridge-Homeseer4 see's a virtual device type under the garage door (type unknown), it will instead use "opening" and "closing" controls, in order to effectively show the garage door opening and closing in HomeKit. You will need to set up a virtual garage door device in HomeSeer, and corresponding events to control it. I also have a wireless sensor that shows when the garage door is fully open, and use the mimo-lite sensor to show when the door is fully closed, although the events can be edited if you don't have this. Virtual device/events setup screenshots: https://imgur.com/a/i1JHeGi

If you'd like to set this up as a beta for users to test that would be great!