### PR TITLE
Add HS4 Google Nest Thermostat Support

### DIFF
--- a/lib/HomeSeerSystemObject.js
+++ b/lib/HomeSeerSystemObject.js
@@ -219,7 +219,7 @@ class HomeSeerSystem
 					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 999) )
 					return true;		
 		// Thermostat
-		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16 || this.HomeSeerDevices[reference]?.status.device_type.Device_API === 512)
+		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16 || this.HomeSeerDevices[reference]?.status.device_type.Device_API === 512) \\new HS4 plugin has a API of 512 and device type of 8
 					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99 || this.HomeSeerDevices[reference].status.device_type.Device_Type === 8)
 					&&	(this.HomeSeerDevices[reference].status.device_type.Device_SubType === 0) )
 					return true;

--- a/lib/HomeSeerSystemObject.js
+++ b/lib/HomeSeerSystemObject.js
@@ -219,8 +219,8 @@ class HomeSeerSystem
 					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 999) )
 					return true;		
 		// Thermostat
-		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16)
-					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99)
+		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16 || this.HomeSeerDevices[reference]?.status.device_type.Device_API === 512)
+					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99 || this.HomeSeerDevices[reference].status.device_type.Device_Type === 8)
 					&&	(this.HomeSeerDevices[reference].status.device_type.Device_SubType === 0) )
 					return true;
 					

--- a/lib/HomeSeerSystemObject.js
+++ b/lib/HomeSeerSystemObject.js
@@ -219,11 +219,15 @@ class HomeSeerSystem
 					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 999) )
 					return true;		
 		// Thermostat
-		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16 || this.HomeSeerDevices[reference]?.status.device_type.Device_API === 512) \\new HS4 plugin has a API of 512 and device type of 8
-					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99 || this.HomeSeerDevices[reference].status.device_type.Device_Type === 8)
-					&&	(this.HomeSeerDevices[reference].status.device_type.Device_SubType === 0) )
-					return true;
-					
+		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 16)
+				&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99)
+				&&	(this.HomeSeerDevices[reference].status.device_type.Device_SubType === 0) )
+				return true;
+		// Detect New NEST Thermostat API
+		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 512)
+				&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 8)
+				&&	(this.HomeSeerDevices[reference].status.device_type.Device_SubType === 0) )
+				return true;	
 		// Music Root Device
 		if ( 		(this.HomeSeerDevices[reference]?.status.device_type.Device_API === 32)
 					&& 	(this.HomeSeerDevices[reference].status.device_type.Device_Type === 99)

--- a/lib/Setup Thermostat.js
+++ b/lib/Setup Thermostat.js
@@ -16,9 +16,9 @@ function getThermostatAssociatedDevice(rootReference) {
 			throw new SyntaxError(`You specified HomeSeer root reference: ${rootReference} that is not a valid HomeSeer reference. Check your config.json file and fix!`)
 		}
 	
-	if (	(RootStatusInfo.device_type.Device_API 		!= 512) 
-		|| 	(RootStatusInfo.device_type.Device_Type 	!= 8) 
-		|| 	(RootStatusInfo.device_type.Device_SubType 	!= 0)
+	if (	!((RootStatusInfo.device_type.Device_API 		=== 16 || RootStatusInfo.device_type.Device_API 		=== 512) 
+		|| 	(RootStatusInfo.device_type.Device_Type 	=== 99 || RootStatusInfo.device_type.Device_Type 	=== 8) 
+		|| 	(RootStatusInfo.device_type.Device_SubType 	=== 0))
 		) {
 			throw new SyntaxError(`You specified HomeSeer reference: ${RootStatusInfo.ref} as a Thermostat Root Device, but it appears not to be the root device for a Thermostat. Check your config.json file and fix!`)
 		}

--- a/lib/Setup Thermostat.js
+++ b/lib/Setup Thermostat.js
@@ -85,10 +85,10 @@ function identifyThermostatData(thermostatRoot, allAccessories)
 							if (currentDeviceStatusInfo.interface_name != "GoogleNest") {
 								globals.log("*Warning* - Found a Temperature device of Type 16, Subtype:0 but device is not using the 'Nest' thermostat plugin. Setting of 'ref' value may be incorrect. You may need to use the 'complex' configuration procedure. Please report this as an issue on github so a correction can be made. Also see wiki entry on Thermostats for additional information. Interface name is: " + currentDeviceStatusInfo.interface_name)
 							}
-							configuration.ref = currentDeviceStatusInfo.ref // 2:1
+							configuration.ref = currentDeviceStatusInfo.ref // 16:1
 							break;
 						case 5: 
-							configuration.humidityRef = currentDeviceStatusInfo.ref // 2:5
+							configuration.humidityRef = currentDeviceStatusInfo.ref // 16:5
 							break;
 						case 6: // status of HVAC
 							configuration.stateRef = currentDeviceStatusInfo.ref;
@@ -97,10 +97,10 @@ function identifyThermostatData(thermostatRoot, allAccessories)
 			case 17: // Setpoints for the GoogleNest HS4
 				switch(currentDeviceStatusInfo.device_type.Device_SubType) {
 					case 1: // Heating Setpoints
-						configuration.heatingSetpointRef = currentDeviceStatusInfo.ref; // 6:1
+						configuration.heatingSetpointRef = currentDeviceStatusInfo.ref; // 17:1
 						break;
 					case 2: // Cooling Setpoint
-						configuration.coolingSetpointRef = currentDeviceStatusInfo.ref; // 6:2
+						configuration.coolingSetpointRef = currentDeviceStatusInfo.ref; // 17:2
 						break;
 					case 3: // Controlling HVAC
 						configuration.controlRef = currentDeviceStatusInfo.ref;

--- a/lib/Setup Thermostat.js
+++ b/lib/Setup Thermostat.js
@@ -83,7 +83,7 @@ function identifyThermostatData(thermostatRoot, allAccessories)
 				switch(currentDeviceStatusInfo.device_type.Device_SubType) {
 						case 0: // for the Nest Interface
 							if (currentDeviceStatusInfo.interface_name != "GoogleNest") {
-								globals.log("*Warning* - Found a Temperature device of Type 2, Subtype:0 but device is not using the 'Nest' thermostat plugin. Setting of 'ref' value may be incorrect. You may need to use the 'complex' configuration procedure. Please report this as an issue on github so a correction can be made. Also see wiki entry on Thermostats for additional information. Interface name is: " + currentDeviceStatusInfo.interface_name)
+								globals.log("*Warning* - Found a Temperature device of Type 16, Subtype:0 but device is not using the 'Nest' thermostat plugin. Setting of 'ref' value may be incorrect. You may need to use the 'complex' configuration procedure. Please report this as an issue on github so a correction can be made. Also see wiki entry on Thermostats for additional information. Interface name is: " + currentDeviceStatusInfo.interface_name)
 							}
 							configuration.ref = currentDeviceStatusInfo.ref // 2:1
 							break;

--- a/lib/Setup Thermostat.js
+++ b/lib/Setup Thermostat.js
@@ -16,8 +16,8 @@ function getThermostatAssociatedDevice(rootReference) {
 			throw new SyntaxError(`You specified HomeSeer root reference: ${rootReference} that is not a valid HomeSeer reference. Check your config.json file and fix!`)
 		}
 	
-	if (	(RootStatusInfo.device_type.Device_API 		!= 16) 
-		|| 	(RootStatusInfo.device_type.Device_Type 	!= 99) 
+	if (	(RootStatusInfo.device_type.Device_API 		!= 512) 
+		|| 	(RootStatusInfo.device_type.Device_Type 	!= 8) 
 		|| 	(RootStatusInfo.device_type.Device_SubType 	!= 0)
 		) {
 			throw new SyntaxError(`You specified HomeSeer reference: ${RootStatusInfo.ref} as a Thermostat Root Device, but it appears not to be the root device for a Thermostat. Check your config.json file and fix!`)
@@ -79,6 +79,34 @@ function identifyThermostatData(thermostatRoot, allAccessories)
 			case 8: // Hold Mode
 			case 9: // Operating Mode
 			case 10: // Additional Temperature
+			case 16: // Temperature for the GoogleNest HS4 Interface
+				switch(currentDeviceStatusInfo.device_type.Device_SubType) {
+						case 0: // for the Nest Interface
+							if (currentDeviceStatusInfo.interface_name != "GoogleNest") {
+								globals.log("*Warning* - Found a Temperature device of Type 2, Subtype:0 but device is not using the 'Nest' thermostat plugin. Setting of 'ref' value may be incorrect. You may need to use the 'complex' configuration procedure. Please report this as an issue on github so a correction can be made. Also see wiki entry on Thermostats for additional information. Interface name is: " + currentDeviceStatusInfo.interface_name)
+							}
+							configuration.ref = currentDeviceStatusInfo.ref // 2:1
+							break;
+						case 5: 
+							configuration.humidityRef = currentDeviceStatusInfo.ref // 2:5
+							break;
+						case 6: // status of HVAC
+							configuration.stateRef = currentDeviceStatusInfo.ref;
+							break;
+				}
+			case 17: // Setpoints for the GoogleNest HS4
+				switch(currentDeviceStatusInfo.device_type.Device_SubType) {
+					case 1: // Heating Setpoints
+						configuration.heatingSetpointRef = currentDeviceStatusInfo.ref; // 6:1
+						break;
+					case 2: // Cooling Setpoint
+						configuration.coolingSetpointRef = currentDeviceStatusInfo.ref; // 6:2
+						break;
+					case 3: // Controlling HVAC
+						configuration.controlRef = currentDeviceStatusInfo.ref;
+						break;
+				}
+				break;
 			default:
 				break;
 		}


### PR DESCRIPTION
Specifically for people that migrated their Nest accounts to Google Nest accounts.  

New HS4 plugin for GoogleNest uses different API number and device numbers, which prevents it from being imported correctly. 

Now you should be able to add the root thermostat device and it will import correctly.  Been working okay for the last couple hours on my setup.  Only issue is it appears the GoogleAPI has some polling limitations per minute, but for regular users it shouldn't be an issue.  